### PR TITLE
handle attempt to parse an empty expression

### DIFF
--- a/spdxexp/parse.go
+++ b/spdxexp/parse.go
@@ -17,6 +17,9 @@ type tokenStream struct {
 }
 
 func Parse(source string) (*Node, error) {
+	if len(source) == 0 {
+		return nil, errors.New("parse error - cannot parse empty string")
+	}
 	tokens, err := scan(source)
 	if err != nil {
 		return nil, err

--- a/spdxexp/parse_test.go
+++ b/spdxexp/parse_test.go
@@ -28,6 +28,8 @@ func TestParse(t *testing.T) {
 			},
 			"MIT", nil},
 
+		{"empty expression", "", nil, "", errors.New("parse error - cannot parse empty string")},
+
 		{"OR Expression", "MIT OR Apache-2.0",
 			&Node{
 				role: ExpressionNode,

--- a/spdxexp/satisfies.go
+++ b/spdxexp/satisfies.go
@@ -39,6 +39,9 @@ func Satisfies(testExpression string, allowedList []string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if len(allowedList) == 0 {
+		return false, errors.New("allowedList requires at least one element, but is empty")
+	}
 	allowedNodes, err := stringsToNodes(allowedList)
 	if err != nil {
 		return false, err

--- a/spdxexp/satisfies_test.go
+++ b/spdxexp/satisfies_test.go
@@ -1,6 +1,7 @@
 package spdxexp
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,6 +20,8 @@ func TestSatisfies(t *testing.T) {
 		// TODO: Commented out tests are not yet supported.
 		{"MIT satisfies [MIT]", "MIT", []string{"MIT"}, true, nil},
 		{"! MIT satisfies [Apache-2.0]", "MIT", []string{"Apache-2.0"}, false, nil},
+		{"err - <empty expression> satisfies MIT", "", []string{"MIT"}, false, errors.New("parse error - cannot parse empty string")},
+		{"err - MIT satisfies <empty allow list>", "MIT", []string{}, false, errors.New("allowedList requires at least one element, but is empty")},
 
 		{"MIT satisfies [MIT, Apache-2.0]", "MIT", []string{"MIT", "Apache-2.0"}, true, nil},
 		{"MIT OR Apache-2.0 satisfies [MIT]", "MIT OR Apache-2.0", []string{"MIT"}, true, nil},

--- a/spdxexp/scan_test.go
+++ b/spdxexp/scan_test.go
@@ -19,6 +19,7 @@ func TestScan(t *testing.T) {
 			[]token{
 				{role: LicenseToken, value: "MIT"},
 			}, nil},
+		{"empty expression", "", nil, nil},
 		{"two licenses using AND", "MIT AND Apache-2.0",
 			[]token{
 				{role: LicenseToken, value: "MIT"},


### PR DESCRIPTION
Fixes https://github.com/github/ospo/issues/242

### Description

Prevent `runtime error: invalid memory address or nil pointer dereference` when attempting to parse an empty expression string.  Added check that returns error if the expression string is empty.

New error: `parse error - cannot parse empty string`

### Impact

Parse returns the error to Satisfies which also returns the error.

```
satisfies("", "MIT")
```
returns `false, error{"parse error - cannot parse empty string"}`
