### PR TITLE
handle non-existent license gracefully

### DIFF
--- a/spdxexp/parse_test.go
+++ b/spdxexp/parse_test.go
@@ -30,6 +30,9 @@ func TestParse(t *testing.T) {
 
 		{"empty expression", "", nil, "", errors.New("parse error - cannot parse empty string")},
 
+		{"invalid license", "NON-EXISTENT-LICENSE", nil, "",
+			errors.New("unknown license 'NON-EXISTENT-LICENSE' at offset 0")},
+
 		{"OR Expression", "MIT OR Apache-2.0",
 			&node{
 				role: expressionNode,

--- a/spdxexp/satisfies_test.go
+++ b/spdxexp/satisfies_test.go
@@ -20,8 +20,12 @@ func TestSatisfies(t *testing.T) {
 		// TODO: Commented out tests are not yet supported.
 		{"MIT satisfies [MIT]", "MIT", []string{"MIT"}, true, nil},
 		{"! MIT satisfies [Apache-2.0]", "MIT", []string{"Apache-2.0"}, false, nil},
-		{"err - <empty expression> satisfies MIT", "", []string{"MIT"}, false, errors.New("parse error - cannot parse empty string")},
-		{"err - MIT satisfies <empty allow list>", "MIT", []string{}, false, errors.New("allowedList requires at least one element, but is empty")},
+		{"err - <empty expression> satisfies MIT", "", []string{"MIT"}, false,
+			errors.New("parse error - cannot parse empty string")},
+		{"err - MIT satisfies <empty allow list>", "MIT", []string{}, false,
+			errors.New("allowedList requires at least one element, but is empty")},
+		{"err - invalid license", "NON-EXISTENT-LICENSE", []string{"MIT", "Apache-2.0"}, false,
+			errors.New("unknown license 'NON-EXISTENT-LICENSE' at offset 0")},
 
 		{"MIT satisfies [MIT, Apache-2.0]", "MIT", []string{"MIT", "Apache-2.0"}, true, nil},
 		{"MIT OR Apache-2.0 satisfies [MIT]", "MIT OR Apache-2.0", []string{"MIT"}, true, nil},

--- a/spdxexp/scan.go
+++ b/spdxexp/scan.go
@@ -217,6 +217,8 @@ func (exp *expressionStream) readLicense() *token {
 
 	// license not found in indices, need to reset index since readID advanced it
 	exp.index = index
+	errmsg := fmt.Sprintf("unknown license '%s' at offset %d", license, exp.index)
+	exp.err = errors.New(errmsg)
 	return nil
 }
 


### PR DESCRIPTION
Fixes #12 

ReadIdentifier is the last function that attempts to consume a token.  If it fails to find a valid license, it was returning nil and resetting the index pointer.  Now it sets an error reporting the license name that was invalid.  This should make it easier for policy writers to get better information about what failed.

Prior to this PR the error message would be: `"unexpected 'B' at offset 0"`

This PR sets the error in ReadIdentifier which has access to the full license name that was attempted.  This allows the error message to be: `"unknown license 'BAD-LICENSE' at offset 0"`.
