### PR TITLE
add support for caller defined set of license extensions

### DIFF
--- a/spdxexp/parse.go
+++ b/spdxexp/parse.go
@@ -16,8 +16,8 @@ type tokenStream struct {
 	err    error
 }
 
-func parse(source string, options Options) (*node, error) {
-	// NOTE: If parse becomes public, the options will need to be processed with `processOptions(options)`
+func parse(source string, options *Options) (*node, error) {
+	options = processOptions(options)
 
 	if len(source) == 0 {
 		return nil, errors.New("parse error - cannot parse empty string")

--- a/spdxexp/parse_test.go
+++ b/spdxexp/parse_test.go
@@ -12,13 +12,13 @@ func TestParse(t *testing.T) {
 	tests := []struct {
 		name       string
 		expression string
-		options    Options
+		options    *Options
 		node       *node
 		nodestr    string
 		err        error
 	}{
 		{"single license",
-			"MIT", Options{},
+			"MIT", nil,
 			&node{
 				role: licenseNode,
 				exp:  nil,
@@ -30,7 +30,7 @@ func TestParse(t *testing.T) {
 			"MIT", nil},
 
 		{"single license - diff case",
-			"mit", Options{},
+			"mit", nil,
 			&node{
 				role: licenseNode,
 				exp:  nil,
@@ -41,12 +41,12 @@ func TestParse(t *testing.T) {
 			},
 			"MIT", nil},
 
-		{"empty expression", "", Options{}, nil, "", errors.New("parse error - cannot parse empty string")},
+		{"empty expression", "", nil, nil, "", errors.New("parse error - cannot parse empty string")},
 
-		{"invalid license", "NON-EXISTENT-LICENSE", Options{}, nil, "",
+		{"invalid license", "NON-EXISTENT-LICENSE", nil, nil, "",
 			errors.New("unknown license 'NON-EXISTENT-LICENSE' at offset 0")},
 
-		{"OR Expression", "MIT OR Apache-2.0", Options{},
+		{"OR Expression", "MIT OR Apache-2.0", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -72,7 +72,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: MIT or RIGHT: Apache-2.0 }", nil},
-		{"AND Expression", "MIT AND Apache-2.0", Options{},
+		{"AND Expression", "MIT AND Apache-2.0", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -98,7 +98,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: MIT and RIGHT: Apache-2.0 }", nil},
-		{"OR-AND Expression", "MIT OR Apache-2.0 AND GPL-2.0", Options{},
+		{"OR-AND Expression", "MIT OR Apache-2.0 AND GPL-2.0", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -145,7 +145,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: MIT or RIGHT: { LEFT: Apache-2.0 and RIGHT: GPL-2.0 } }", nil},
-		{"OR(AND) Expression", "MIT OR (Apache-2.0 AND GPL-2.0)", Options{},
+		{"OR(AND) Expression", "MIT OR (Apache-2.0 AND GPL-2.0)", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -192,7 +192,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: MIT or RIGHT: { LEFT: Apache-2.0 and RIGHT: GPL-2.0 } }", nil},
-		{"AND-OR Expression", "MIT AND Apache-2.0 OR GPL-2.0", Options{},
+		{"AND-OR Expression", "MIT AND Apache-2.0 OR GPL-2.0", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -239,7 +239,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: { LEFT: MIT and RIGHT: Apache-2.0 } or RIGHT: GPL-2.0 }", nil},
-		{"AND(OR) Expression", "MIT AND (Apache-2.0 OR GPL-2.0)", Options{},
+		{"AND(OR) Expression", "MIT AND (Apache-2.0 OR GPL-2.0)", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -289,7 +289,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: MIT and RIGHT: { LEFT: Apache-2.0 or RIGHT: GPL-2.0 } }", nil},
-		{"OR-AND-OR Expression", "MIT OR ISC AND Apache-2.0 OR GPL-2.0", Options{},
+		{"OR-AND-OR Expression", "MIT OR ISC AND Apache-2.0 OR GPL-2.0", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -358,7 +358,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: MIT or RIGHT: { LEFT: { LEFT: ISC and RIGHT: Apache-2.0 } or RIGHT: GPL-2.0 } }", nil},
-		{"(OR)AND(OR) Expression", "(MIT OR ISC) AND (Apache-2.0 OR GPL-2.0)", Options{},
+		{"(OR)AND(OR) Expression", "(MIT OR ISC) AND (Apache-2.0 OR GPL-2.0)", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -426,7 +426,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: { LEFT: MIT or RIGHT: ISC } and RIGHT: { LEFT: Apache-2.0 or RIGHT: GPL-2.0 } }", nil},
-		{"OR(AND)OR Expression", "MIT OR (ISC AND Apache-2.0) OR GPL-2.0", Options{},
+		{"OR(AND)OR Expression", "MIT OR (ISC AND Apache-2.0) OR GPL-2.0", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -495,7 +495,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: MIT or RIGHT: { LEFT: { LEFT: ISC and RIGHT: Apache-2.0 } or RIGHT: GPL-2.0 } }", nil},
-		{"OR-OR-OR Expression", "MIT OR ISC OR Apache-2.0 OR GPL-2.0", Options{},
+		{"OR-OR-OR Expression", "MIT OR ISC OR Apache-2.0 OR GPL-2.0", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -563,7 +563,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: MIT or RIGHT: { LEFT: ISC or RIGHT: { LEFT: Apache-2.0 or RIGHT: GPL-2.0 } } }", nil},
-		{"AND-OR-AND Expression", "MIT AND ISC OR Apache-2.0 AND GPL-2.0", Options{},
+		{"AND-OR-AND Expression", "MIT AND ISC OR Apache-2.0 AND GPL-2.0", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -631,7 +631,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: { LEFT: MIT and RIGHT: ISC } or RIGHT: { LEFT: Apache-2.0 and RIGHT: GPL-2.0 } }", nil},
-		{"(AND)OR(AND) Expression", "(MIT AND ISC) OR (Apache-2.0 AND GPL-2.0)", Options{},
+		{"(AND)OR(AND) Expression", "(MIT AND ISC) OR (Apache-2.0 AND GPL-2.0)", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -699,7 +699,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: { LEFT: MIT and RIGHT: ISC } or RIGHT: { LEFT: Apache-2.0 and RIGHT: GPL-2.0 } }", nil},
-		{"AND(OR)AND Expression", "MIT AND (ISC OR Apache-2.0) AND GPL-2.0", Options{},
+		{"AND(OR)AND Expression", "MIT AND (ISC OR Apache-2.0) AND GPL-2.0", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -769,7 +769,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: MIT and RIGHT: { LEFT: { LEFT: ISC or RIGHT: Apache-2.0 } and RIGHT: GPL-2.0 } }", nil},
-		{"AND-AND-AND Expression", "MIT AND ISC AND Apache-2.0 AND GPL-2.0", Options{},
+		{"AND-AND-AND Expression", "MIT AND ISC AND Apache-2.0 AND GPL-2.0", nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -841,7 +841,7 @@ func TestParse(t *testing.T) {
 			"{ LEFT: MIT and RIGHT: { LEFT: ISC and RIGHT: { LEFT: Apache-2.0 and RIGHT: GPL-2.0 } } }", nil},
 		{"kitchen sink",
 			"   (MIT AND Apache-1.0+)   OR   DocumentRef-spdx-tool-1.2:LicenseRef-MIT-Style-2 OR (GPL-2.0 WITH Bison-exception-2.2)",
-			Options{},
+			nil,
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -911,7 +911,7 @@ func TestParse(t *testing.T) {
 			},
 			"{ LEFT: { LEFT: MIT and RIGHT: Apache-1.0+ } or RIGHT: { LEFT: DocumentRef-spdx-tool-1.2:LicenseRef-MIT-Style-2 or RIGHT: GPL-2.0 with Bison-exception-2.2 } }", nil,
 		},
-		{"extension is expression", "X-BSD-3-Clause-Golang", Options{[]string{"X-BSD-3-Clause-Golang"}},
+		{"extension is expression", "X-BSD-3-Clause-Golang", &Options{[]string{"X-BSD-3-Clause-Golang"}},
 			&node{
 				role: licenseNode,
 				exp:  nil,
@@ -921,7 +921,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"X-BSD-3-Clause-Golang", nil},
-		{"extension in expression", "(MIT OR X-BSD-3-Clause-Golang)", Options{[]string{"X-BSD-3-Clause-Golang"}},
+		{"extension in expression", "(MIT OR X-BSD-3-Clause-Golang)", &Options{[]string{"X-BSD-3-Clause-Golang"}},
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -947,7 +947,7 @@ func TestParse(t *testing.T) {
 				ref: nil,
 			},
 			"{ LEFT: MIT or RIGHT: X-BSD-3-Clause-Golang }", nil},
-		{"extension not in expression", "(MIT OR Apache-2.0)", Options{[]string{"X-BSD-3-Clause-Golang"}},
+		{"extension not in expression", "(MIT OR Apache-2.0)", &Options{[]string{"X-BSD-3-Clause-Golang"}},
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{
@@ -974,7 +974,7 @@ func TestParse(t *testing.T) {
 			},
 			"{ LEFT: MIT or RIGHT: Apache-2.0 }", nil},
 		{"extension (one of) in expression", "BSD-3-Clause OR X-BSD-3-Clause-Golang",
-			Options{[]string{"X-BSD-3-Clause-Golang", "X-BSD-2-Clause-Golang"}},
+			&Options{[]string{"X-BSD-3-Clause-Golang", "X-BSD-2-Clause-Golang"}},
 			&node{
 				role: expressionNode,
 				exp: &expressionNodePartial{

--- a/spdxexp/satisfies.go
+++ b/spdxexp/satisfies.go
@@ -48,7 +48,7 @@ type Options struct {
 //	      Options{LicenseExtensionList: []string{“X-BSD-3-Clause-Golang"}} // returns true
 //	    SatisfiesWithExtensions(“X-BSD-3-Clause-Golang”, []string{"MIT", "Apache-2.0"},
 //	      Options{LicenseExtensionList: []string{“X-BSD-3-Clause-Golang"}} // returns false - test license is not in allowed List
-func Satisfies(testExpression string, allowedList []string, options Options) (bool, error) {
+func Satisfies(testExpression string, allowedList []string, options *Options) (bool, error) {
 	options = processOptions(options)
 
 	expressionNode, err := parse(testExpression, options)
@@ -77,15 +77,16 @@ func Satisfies(testExpression string, allowedList []string, options Options) (bo
 	return false, nil
 }
 
-func processOptions(options Options) Options {
-	if options.LicenseExtensionList == nil {
-		options.LicenseExtensionList = []string{}
+func processOptions(options *Options) *Options {
+	if options == nil {
+		options = &Options{}
 	}
+	// LicenseExtensionList defaults to empty []string when var is assigned Options{}
 	return options
 }
 
 // stringsToNodes converts an array of single license strings to to an array of license nodes.
-func stringsToNodes(licenseStrings []string, options Options) ([]*node, error) {
+func stringsToNodes(licenseStrings []string, options *Options) ([]*node, error) {
 	nodes := make([]*node, len(licenseStrings))
 	for i, s := range licenseStrings {
 		node, err := parse(s, options)

--- a/spdxexp/satisfies_test.go
+++ b/spdxexp/satisfies_test.go
@@ -12,111 +12,111 @@ func TestSatisfies(t *testing.T) {
 		name           string
 		repoExpression string
 		allowedList    []string
-		options        Options
+		options        *Options
 		satisfied      bool
 		err            error
 	}{
 		// TODO: Test error conditions (e.g. GPL is an invalid license, Apachie + has invalid + operator)
 		// regression tests from spdx-satisfies.js - comments for satisfies function
 		// TODO: Commented out tests are not yet supported.
-		{"MIT satisfies [MIT]", "MIT", []string{"MIT"}, Options{}, true, nil},
-		{"miT satisfies [MIT]", "miT", []string{"MIT"}, Options{}, true, nil},
-		{"MIT satisfies [mit]", "MIT", []string{"mit"}, Options{}, true, nil},
-		{"! MIT satisfies [Apache-2.0]", "MIT", []string{"Apache-2.0"}, Options{}, false, nil},
-		{"err - <empty expression> satisfies MIT", "", []string{"MIT"}, Options{}, false,
+		{"MIT satisfies [MIT]", "MIT", []string{"MIT"}, nil, true, nil},
+		{"miT satisfies [MIT]", "miT", []string{"MIT"}, nil, true, nil},
+		{"MIT satisfies [mit]", "MIT", []string{"mit"}, nil, true, nil},
+		{"! MIT satisfies [Apache-2.0]", "MIT", []string{"Apache-2.0"}, nil, false, nil},
+		{"err - <empty expression> satisfies MIT", "", []string{"MIT"}, nil, false,
 			errors.New("parse error - cannot parse empty string")},
-		{"err - MIT satisfies <empty allow list>", "MIT", []string{}, Options{}, false,
+		{"err - MIT satisfies <empty allow list>", "MIT", []string{}, nil, false,
 			errors.New("allowedList requires at least one element, but is empty")},
-		{"err - invalid license", "NON-EXISTENT-LICENSE", []string{"MIT", "Apache-2.0"}, Options{}, false,
+		{"err - invalid license", "NON-EXISTENT-LICENSE", []string{"MIT", "Apache-2.0"}, nil, false,
 			errors.New("unknown license 'NON-EXISTENT-LICENSE' at offset 0")},
 
-		{"MIT satisfies [MIT, Apache-2.0]", "MIT", []string{"MIT", "Apache-2.0"}, Options{}, true, nil},
-		{"MIT OR Apache-2.0 satisfies [MIT]", "MIT OR Apache-2.0", []string{"MIT"}, Options{}, true, nil},
-		{"! GPL-2.0 satisfies [MIT, Apache-2.0]", "GPL-2.0", []string{"MIT", "Apache-2.0"}, Options{}, false, nil},
-		{"! MIT OR Apache-2.0 satisfies [GPL-2.0]", "MIT OR Apache-2.0", []string{"GPL-2.0"}, Options{}, false, nil},
+		{"MIT satisfies [MIT, Apache-2.0]", "MIT", []string{"MIT", "Apache-2.0"}, nil, true, nil},
+		{"MIT OR Apache-2.0 satisfies [MIT]", "MIT OR Apache-2.0", []string{"MIT"}, nil, true, nil},
+		{"! GPL-2.0 satisfies [MIT, Apache-2.0]", "GPL-2.0", []string{"MIT", "Apache-2.0"}, nil, false, nil},
+		{"! MIT OR Apache-2.0 satisfies [GPL-2.0]", "MIT OR Apache-2.0", []string{"GPL-2.0"}, nil, false, nil},
 
-		{"Apache-2.0 AND MIT satisfies [MIT, APACHE-2.0]", "Apache-2.0 AND MIT", []string{"MIT", "APACHE-2.0"}, Options{}, true, nil},
-		{"apache-2.0 AND mit satisfies [MIT, APACHE-2.0]", "apache-2.0 AND mit", []string{"MIT", "APACHE-2.0"}, Options{}, true, nil},
-		{"Apache-2.0 AND MIT satisfies [MIT, Apache-2.0]", "Apache-2.0 AND MIT", []string{"MIT", "Apache-2.0"}, Options{}, true, nil},
-		{"MIT AND Apache-2.0 satisfies [MIT, Apache-2.0]", "MIT AND Apache-2.0", []string{"MIT", "Apache-2.0"}, Options{}, true, nil},
-		{"! MIT AND Apache-2.0 satisfies [MIT]", "MIT AND Apache-2.0", []string{"MIT"}, Options{}, false, nil},
-		{"! GPL-2.0 satisfies [MIT, Apache-2.0]", "GPL-2.0", []string{"MIT", "Apache-2.0"}, Options{}, false, nil},
+		{"Apache-2.0 AND MIT satisfies [MIT, APACHE-2.0]", "Apache-2.0 AND MIT", []string{"MIT", "APACHE-2.0"}, nil, true, nil},
+		{"apache-2.0 AND mit satisfies [MIT, APACHE-2.0]", "apache-2.0 AND mit", []string{"MIT", "APACHE-2.0"}, nil, true, nil},
+		{"Apache-2.0 AND MIT satisfies [MIT, Apache-2.0]", "Apache-2.0 AND MIT", []string{"MIT", "Apache-2.0"}, nil, true, nil},
+		{"MIT AND Apache-2.0 satisfies [MIT, Apache-2.0]", "MIT AND Apache-2.0", []string{"MIT", "Apache-2.0"}, nil, true, nil},
+		{"! MIT AND Apache-2.0 satisfies [MIT]", "MIT AND Apache-2.0", []string{"MIT"}, nil, false, nil},
+		{"! GPL-2.0 satisfies [MIT, Apache-2.0]", "GPL-2.0", []string{"MIT", "Apache-2.0"}, nil, false, nil},
 
-		{"MIT AND Apache-2.0 satisfies [MIT, Apache-1.0, Apache-2.0]", "MIT AND Apache-2.0", []string{"MIT", "Apache-1.0", "Apache-2.0"}, Options{}, true, nil},
+		{"MIT AND Apache-2.0 satisfies [MIT, Apache-1.0, Apache-2.0]", "MIT AND Apache-2.0", []string{"MIT", "Apache-1.0", "Apache-2.0"}, nil, true, nil},
 
-		{"Apache-1.0+ satisfies [Apache-2.0]", "Apache-1.0+", []string{"Apache-2.0"}, Options{}, true, nil},
-		{"Apache-1.0+ satisfies [Apache-2.0+]", "Apache-1.0+", []string{"Apache-2.0+"}, Options{}, true, nil}, // TODO: Fails here but passes js
-		{"! Apache-1.0 satisfies [Apache-2.0+]", "Apache-1.0", []string{"Apache-2.0+"}, Options{}, false, nil},
-		{"Apache-2.0 satisfies [Apache-2.0+]", "Apache-2.0", []string{"Apache-2.0+"}, Options{}, true, nil},
-		{"! Apache-3.0 satisfies [Apache-2.0+]", "Apache-3.0", []string{"Apache-2.0+"}, Options{}, false, errors.New("unknown license 'Apache-3.0' at offset 0")},
+		{"Apache-1.0+ satisfies [Apache-2.0]", "Apache-1.0+", []string{"Apache-2.0"}, nil, true, nil},
+		{"Apache-1.0+ satisfies [Apache-2.0+]", "Apache-1.0+", []string{"Apache-2.0+"}, nil, true, nil}, // TODO: Fails here but passes js
+		{"! Apache-1.0 satisfies [Apache-2.0+]", "Apache-1.0", []string{"Apache-2.0+"}, nil, false, nil},
+		{"Apache-2.0 satisfies [Apache-2.0+]", "Apache-2.0", []string{"Apache-2.0+"}, nil, true, nil},
+		{"! Apache-3.0 satisfies [Apache-2.0+]", "Apache-3.0", []string{"Apache-2.0+"}, nil, false, errors.New("unknown license 'Apache-3.0' at offset 0")},
 
-		{"! Apache-1.0 satisfies [Apache-2.0-or-later]", "Apache-1.0", []string{"Apache-2.0-or-later"}, Options{}, false, nil},
-		{"Apache-2.0 satisfies [Apache-2.0-or-later]", "Apache-2.0", []string{"Apache-2.0-or-later"}, Options{}, true, nil},
-		{"! Apache-3.0 satisfies [Apache-2.0-or-later]", "Apache-3.0", []string{"Apache-2.0-or-later"}, Options{}, false, errors.New("unknown license 'Apache-3.0' at offset 0")},
+		{"! Apache-1.0 satisfies [Apache-2.0-or-later]", "Apache-1.0", []string{"Apache-2.0-or-later"}, nil, false, nil},
+		{"Apache-2.0 satisfies [Apache-2.0-or-later]", "Apache-2.0", []string{"Apache-2.0-or-later"}, nil, true, nil},
+		{"! Apache-3.0 satisfies [Apache-2.0-or-later]", "Apache-3.0", []string{"Apache-2.0-or-later"}, nil, false, errors.New("unknown license 'Apache-3.0' at offset 0")},
 
-		{"! Apache-1.0 satisfies [Apache-2.0-only]", "Apache-1.0", []string{"Apache-2.0-only"}, Options{}, false, nil},
-		{"Apache-2.0 satisfies [Apache-2.0-only]", "Apache-2.0", []string{"Apache-2.0-only"}, Options{}, true, nil},
-		{"! Apache-3.0 satisfies [Apache-2.0-only]", "Apache-3.0", []string{"Apache-2.0-only"}, Options{}, false, errors.New("unknown license 'Apache-3.0' at offset 0")},
+		{"! Apache-1.0 satisfies [Apache-2.0-only]", "Apache-1.0", []string{"Apache-2.0-only"}, nil, false, nil},
+		{"Apache-2.0 satisfies [Apache-2.0-only]", "Apache-2.0", []string{"Apache-2.0-only"}, nil, true, nil},
+		{"! Apache-3.0 satisfies [Apache-2.0-only]", "Apache-3.0", []string{"Apache-2.0-only"}, nil, false, errors.New("unknown license 'Apache-3.0' at offset 0")},
 
 		// regression tests from spdx-satisfies.js - assert statements in README
 		// TODO: Commented out tests are not yet supported.
-		{"MIT satisfies [MIT]", "MIT", []string{"MIT"}, Options{}, true, nil},
+		{"MIT satisfies [MIT]", "MIT", []string{"MIT"}, nil, true, nil},
 
-		{"MIT satisfies [ISC, MIT]", "MIT", []string{"ISC", "MIT"}, Options{}, true, nil},
-		{"Zlib satisfies [ISC, MIT, Zlib]", "Zlib", []string{"ISC", "MIT", "Zlib"}, Options{}, true, nil},
-		{"! GPL-3.0 satisfies [ISC, MIT]", "GPL-3.0", []string{"ISC", "MIT"}, Options{}, false, nil},
-		{"GPL-2.0 satisfies [GPL-2.0+]", "GPL-2.0", []string{"GPL-2.0+"}, Options{}, true, nil},                 // TODO: Fails here but passes js
-		{"GPL-2.0 satisfies [GPL-2.0-or-later]", "GPL-2.0", []string{"GPL-2.0-or-later"}, Options{}, true, nil}, // TODO: Fails here and js
-		{"GPL-3.0 satisfies [GPL-2.0+]", "GPL-3.0", []string{"GPL-2.0+"}, Options{}, true, nil},
-		{"GPL-1.0-or-later satisfies [GPL-2.0-or-later]", "GPL-1.0-or-later", []string{"GPL-2.0-or-later"}, Options{}, true, nil},
-		{"GPL-1.0+ satisfies [GPL-2.0+]", "GPL-1.0+", []string{"GPL-2.0+"}, Options{}, true, nil},
-		{"! GPL-1.0 satisfies [GPL-2.0+]", "GPL-1.0", []string{"GPL-2.0+"}, Options{}, false, nil},
-		{"GPL-2.0-only satisfies [GPL-2.0-only]", "GPL-2.0-only", []string{"GPL-2.0-only"}, Options{}, true, nil},
-		{"GPL-3.0-only satisfies [GPL-2.0+]", "GPL-3.0-only", []string{"GPL-2.0+"}, Options{}, true, nil},
+		{"MIT satisfies [ISC, MIT]", "MIT", []string{"ISC", "MIT"}, nil, true, nil},
+		{"Zlib satisfies [ISC, MIT, Zlib]", "Zlib", []string{"ISC", "MIT", "Zlib"}, nil, true, nil},
+		{"! GPL-3.0 satisfies [ISC, MIT]", "GPL-3.0", []string{"ISC", "MIT"}, nil, false, nil},
+		{"GPL-2.0 satisfies [GPL-2.0+]", "GPL-2.0", []string{"GPL-2.0+"}, nil, true, nil},                 // TODO: Fails here but passes js
+		{"GPL-2.0 satisfies [GPL-2.0-or-later]", "GPL-2.0", []string{"GPL-2.0-or-later"}, nil, true, nil}, // TODO: Fails here and js
+		{"GPL-3.0 satisfies [GPL-2.0+]", "GPL-3.0", []string{"GPL-2.0+"}, nil, true, nil},
+		{"GPL-1.0-or-later satisfies [GPL-2.0-or-later]", "GPL-1.0-or-later", []string{"GPL-2.0-or-later"}, nil, true, nil},
+		{"GPL-1.0+ satisfies [GPL-2.0+]", "GPL-1.0+", []string{"GPL-2.0+"}, nil, true, nil},
+		{"! GPL-1.0 satisfies [GPL-2.0+]", "GPL-1.0", []string{"GPL-2.0+"}, nil, false, nil},
+		{"GPL-2.0-only satisfies [GPL-2.0-only]", "GPL-2.0-only", []string{"GPL-2.0-only"}, nil, true, nil},
+		{"GPL-3.0-only satisfies [GPL-2.0+]", "GPL-3.0-only", []string{"GPL-2.0+"}, nil, true, nil},
 
 		{"! GPL-2.0 satisfies [GPL-2.0+ WITH Bison-exception-2.2]",
-			"GPL-2.0", []string{"GPL-2.0+ WITH Bison-exception-2.2"}, Options{}, false, nil},
+			"GPL-2.0", []string{"GPL-2.0+ WITH Bison-exception-2.2"}, nil, false, nil},
 		{"GPL-3.0 WITH Bison-exception-2.2 satisfies [GPL-2.0+ WITH Bison-exception-2.2]",
-			"GPL-3.0 WITH Bison-exception-2.2", []string{"GPL-2.0+ WITH Bison-exception-2.2"}, Options{}, true, nil},
+			"GPL-3.0 WITH Bison-exception-2.2", []string{"GPL-2.0+ WITH Bison-exception-2.2"}, nil, true, nil},
 
-		{"(MIT OR GPL-2.0) satisfies [ISC, MIT]", "(MIT OR GPL-2.0)", []string{"ISC", "MIT"}, Options{}, true, nil},
-		{"(MIT AND GPL-2.0) satisfies [MIT, GPL-2.0]", "(MIT AND GPL-2.0)", []string{"MIT", "GPL-2.0"}, Options{}, true, nil},
+		{"(MIT OR GPL-2.0) satisfies [ISC, MIT]", "(MIT OR GPL-2.0)", []string{"ISC", "MIT"}, nil, true, nil},
+		{"(MIT AND GPL-2.0) satisfies [MIT, GPL-2.0]", "(MIT AND GPL-2.0)", []string{"MIT", "GPL-2.0"}, nil, true, nil},
 		{"MIT AND GPL-2.0 AND ISC satisfies [MIT, GPL-2.0, ISC]",
-			"MIT AND GPL-2.0 AND ISC", []string{"MIT", "GPL-2.0", "ISC"}, Options{}, true, nil},
+			"MIT AND GPL-2.0 AND ISC", []string{"MIT", "GPL-2.0", "ISC"}, nil, true, nil},
 		{"MIT AND GPL-2.0 AND ISC satisfies [ISC, GPL-2.0, MIT]",
-			"MIT AND GPL-2.0 AND ISC", []string{"ISC", "GPL-2.0", "MIT"}, Options{}, true, nil},
+			"MIT AND GPL-2.0 AND ISC", []string{"ISC", "GPL-2.0", "MIT"}, nil, true, nil},
 		{"(MIT OR GPL-2.0) AND ISC satisfies [MIT, ISC]",
-			"(MIT OR GPL-2.0) AND ISC", []string{"MIT", "ISC"}, Options{}, true, nil},
+			"(MIT OR GPL-2.0) AND ISC", []string{"MIT", "ISC"}, nil, true, nil},
 		{"MIT AND ISC satisfies [MIT, GPL-2.0, ISC]",
-			"MIT AND ISC", []string{"MIT", "GPL-2.0", "ISC"}, Options{}, true, nil},
+			"MIT AND ISC", []string{"MIT", "GPL-2.0", "ISC"}, nil, true, nil},
 		{"(MIT OR Apache-2.0) AND (ISC OR GPL-2.0) satisfies [Apache-2.0, ISC]",
-			"(MIT OR Apache-2.0) AND (ISC OR GPL-2.0)", []string{"Apache-2.0", "ISC"}, Options{}, true, nil},
+			"(MIT OR Apache-2.0) AND (ISC OR GPL-2.0)", []string{"Apache-2.0", "ISC"}, nil, true, nil},
 		{"(MIT AND GPL-2.0) satisfies [MIT, GPL-2.0]",
-			"(MIT AND GPL-2.0)", []string{"MIT", "GPL-2.0"}, Options{}, true, nil},
+			"(MIT AND GPL-2.0)", []string{"MIT", "GPL-2.0"}, nil, true, nil},
 		{"(MIT AND GPL-2.0) satisfies [GPL-2.0, MIT]",
-			"(MIT AND GPL-2.0)", []string{"GPL-2.0", "MIT"}, Options{}, true, nil},
+			"(MIT AND GPL-2.0)", []string{"GPL-2.0", "MIT"}, nil, true, nil},
 		{"MIT satisfies [GPL-2.0, MIT, MIT, ISC]",
-			"MIT", []string{"GPL-2.0", "MIT", "MIT", "ISC"}, Options{}, true, nil},
+			"MIT", []string{"GPL-2.0", "MIT", "MIT", "ISC"}, nil, true, nil},
 		{"MIT AND ICU satisfies [MIT, GPL-2.0, ISC, Apache-2.0, ICU]",
-			"MIT AND ICU", []string{"MIT", "GPL-2.0", "ISC", "Apache-2.0", "ICU"}, Options{}, true, nil}, // TODO: This says true and the js version returns true, but it shouldn't.
+			"MIT AND ICU", []string{"MIT", "GPL-2.0", "ISC", "Apache-2.0", "ICU"}, nil, true, nil}, // TODO: This says true and the js version returns true, but it shouldn't.
 		{"! (MIT AND GPL-2.0) satisfies [ISC, GPL-2.0]",
-			"(MIT AND GPL-2.0)", []string{"ISC", "GPL-2.0"}, Options{}, false, nil},
+			"(MIT AND GPL-2.0)", []string{"ISC", "GPL-2.0"}, nil, false, nil},
 		{"! MIT AND (GPL-2.0 OR ISC) satisfies [MIT]",
-			"MIT AND (GPL-2.0 OR ISC)", []string{"MIT"}, Options{}, false, nil},
+			"MIT AND (GPL-2.0 OR ISC)", []string{"MIT"}, nil, false, nil},
 		{"! (MIT OR Apache-2.0) AND (ISC OR GPL-2.0) satisfies [MIT]",
-			"(MIT OR Apache-2.0) AND (ISC OR GPL-2.0)", []string{"MIT"}, Options{}, false, nil},
+			"(MIT OR Apache-2.0) AND (ISC OR GPL-2.0)", []string{"MIT"}, nil, false, nil},
 		{"extension is expression", "X-BSD-3-Clause-Golang",
 			[]string{"MIT", "Apache-2.0", "X-BSD-3-Clause-Golang"},
-			Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang"}}, true, nil},
+			&Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang"}}, true, nil},
 		{"extension in expression", "(MIT OR X-BSD-3-Clause-Golang)",
 			[]string{"MIT", "Apache-2.0", "X-BSD-3-Clause-Golang"},
-			Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang"}}, true, nil},
+			&Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang"}}, true, nil},
 		{"extension not in expression", "(MIT OR Apache-2.0)",
 			[]string{"MIT", "Apache-2.0", "X-BSD-3-Clause-Golang"},
-			Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang"}}, true, nil},
+			&Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang"}}, true, nil},
 		{"extension (one of) in expression", "BSD-3-Clause OR X-BSD-3-Clause-Golang",
 			[]string{"MIT", "Apache-2.0", "X-BSD-3-Clause-Golang"},
-			Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang", "X-BSD-2-Clause-Golang"}}, true, nil},
+			&Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang", "X-BSD-2-Clause-Golang"}}, true, nil},
 	}
 
 	for _, test := range tests {

--- a/spdxexp/scan.go
+++ b/spdxexp/scan.go
@@ -32,8 +32,8 @@ const (
 )
 
 // Scan scans a string expression gathering valid SPDX expression tokens.  Returns error if any tokens are invalid.
-func scan(expression string, options Options) ([]token, error) {
-	// NOTE: If scan becomes public, the options will need to be processed with `processOptions(options)`
+func scan(expression string, options *Options) ([]token, error) {
+	options = processOptions(options)
 
 	var tokens []token
 	var token *token

--- a/spdxexp/scan_test.go
+++ b/spdxexp/scan_test.go
@@ -12,28 +12,28 @@ func TestScan(t *testing.T) {
 	tests := []struct {
 		name       string
 		expression string
-		options    Options
+		options    *Options
 		tokens     []token
 		err        error
 	}{
-		{"single license", "MIT", Options{},
+		{"single license", "MIT", nil,
 			[]token{
 				{role: licenseToken, value: "MIT"},
 			}, nil},
-		{"single license - diff case", "mit", Options{},
+		{"single license - diff case", "mit", nil,
 			[]token{
 				{role: licenseToken, value: "MIT"},
 			}, nil},
-		{"empty expression", "", Options{}, []token(nil), nil},
-		{"invalid license", "NON-EXISTENT-LICENSE", Options{}, []token(nil),
+		{"empty expression", "", nil, []token(nil), nil},
+		{"invalid license", "NON-EXISTENT-LICENSE", nil, []token(nil),
 			errors.New("unknown license 'NON-EXISTENT-LICENSE' at offset 0")},
-		{"two licenses using AND", "MIT AND Apache-2.0", Options{},
+		{"two licenses using AND", "MIT AND Apache-2.0", nil,
 			[]token{
 				{role: licenseToken, value: "MIT"},
 				{role: operatorToken, value: "AND"},
 				{role: licenseToken, value: "Apache-2.0"},
 			}, nil},
-		{"two licenses using OR inside paren", "(MIT OR Apache-2.0)", Options{},
+		{"two licenses using OR inside paren", "(MIT OR Apache-2.0)", nil,
 			[]token{
 				{role: operatorToken, value: "("},
 				{role: licenseToken, value: "MIT"},
@@ -42,7 +42,7 @@ func TestScan(t *testing.T) {
 				{role: operatorToken, value: ")"},
 			}, nil},
 		{"kitchen sink", "   (MIT AND Apache-1.0+)   OR   DocumentRef-spdx-tool-1.2:LicenseRef-MIT-Style-2 OR (GPL-2.0 WITH Bison-exception-2.2)",
-			Options{},
+			nil,
 			[]token{
 				{role: operatorToken, value: "("},
 				{role: licenseToken, value: "MIT"},
@@ -61,11 +61,11 @@ func TestScan(t *testing.T) {
 				{role: exceptionToken, value: "Bison-exception-2.2"},
 				{role: operatorToken, value: ")"},
 			}, nil},
-		{"extension is expression", "X-BSD-3-Clause-Golang", Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang"}},
+		{"extension is expression", "X-BSD-3-Clause-Golang", &Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang"}},
 			[]token{
 				{role: extensionToken, value: "X-BSD-3-Clause-Golang"},
 			}, nil},
-		{"extension in expression", "(MIT OR X-BSD-3-Clause-Golang)", Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang"}},
+		{"extension in expression", "(MIT OR X-BSD-3-Clause-Golang)", &Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang"}},
 			[]token{
 				{role: operatorToken, value: "("},
 				{role: licenseToken, value: "MIT"},
@@ -73,7 +73,7 @@ func TestScan(t *testing.T) {
 				{role: extensionToken, value: "X-BSD-3-Clause-Golang"},
 				{role: operatorToken, value: ")"},
 			}, nil},
-		{"extension not in expression", "(MIT OR Apache-2.0)", Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang"}},
+		{"extension not in expression", "(MIT OR Apache-2.0)", &Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang"}},
 			[]token{
 				{role: operatorToken, value: "("},
 				{role: licenseToken, value: "MIT"},
@@ -82,7 +82,7 @@ func TestScan(t *testing.T) {
 				{role: operatorToken, value: ")"},
 			}, nil},
 		{"extension (one of) in expression", "BSD-3-Clause OR X-BSD-3-Clause-Golang",
-			Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang", "X-BSD-2-Clause-Golang"}},
+			&Options{LicenseExtensionList: []string{"X-BSD-3-Clause-Golang", "X-BSD-2-Clause-Golang"}},
 			[]token{
 				{role: licenseToken, value: "BSD-3-Clause"},
 				{role: operatorToken, value: "OR"},

--- a/spdxexp/test_helper.go
+++ b/spdxexp/test_helper.go
@@ -22,6 +22,6 @@ func getLicenseNode(license string, hasPlus bool) *node {
 // Use this function when the test data is expected to parse successfully.
 func getParsedNode(expression string) *node {
 	// swallows errors
-	n, _ := parse(expression, Options{})
+	n, _ := parse(expression, nil)
 	return n
 }


### PR DESCRIPTION
### Description

There are cases where a license is not in the set of [canonical SPDX licenses](https://spdx.org/licenses/), but an organization wants to be able to accept that license.  This provides a way to pass in the set of license extensions.

### Use Case

Go and the related golang.org/x libraries are all licensed under a BSD-3-Clause license, but with a patent grant from Google that makes a stipulation about not suing them over patent infringement for that package.

ClearlyDefined returns this license as `BSD-3-Clause AND OTHER`.  Adding `OTHER` as an extension is too broad.  The license will be tested as `X-BSD-3-Clause-Golang`.  The license extension list will also include `X-BSD-3-Clause-Golang`.

#### API Change

We decided to go with adding an Options struct to `Satisfies` instead of adding an additional function.  This provides a way to extend `Satisfies` in the future without having to change its current signature or having to add additional functions.

The following all return true:

```go
allowedList := []string{"MIT", "Apache-2.0", "X-BSD-3-Clause-Golang"}
options := spdxexp.Options{LicenseExtensionList: []string{“X-BSD-3-Clause-Golang"}}

Satisfies(“X-BSD-3-Clause-Golang”, allowedList, &options)
Satisfies(“(MIT OR X-BSD-3-Clause-Golang)”, allowedList, &options)
Satisfies(“(MIT OR Apache-2.0)”, allowedList, &options)
Satisfies(“(MIT OR Apache-2.0)”, allowedList, nil)
```

#### Original Proposed API Change -- NOT IMPLEMENTED

**THESE EXAMPLES WERE NOT IMPLEMENTED**

The following are expected to return true:

```go
allowedList := []string{"MIT", "Apache-2.0", "X-BSD-3-Clause-Golang"}
licenseExtensionList := []string{“X-BSD-3-Clause-Golang"}

SatisfiesWithExtensions(“X-BSD-3-Clause-Golang”, allowedList, licenseExtensionList)
SatisfiesWithExtensions(“(MIT OR X-BSD-3-Clause-Golang)”, allowedList, licenseExtensionList)
SatisfiesWithExtensions(“(MIT OR Apache-2.0)”, allowedList, licenseExtensionList)
```

