### PR TITLE
add test that can be easily updated to validate a specific expression to an allowed-list

### DIFF
--- a/spdxexp/satisfies_test.go
+++ b/spdxexp/satisfies_test.go
@@ -28,6 +28,21 @@ func TestValidateLicenses(t *testing.T) {
 	}
 }
 
+// TestSatisfiesSingle lets you quickly test a single call to Satisfies with a specific license expression and allowed list of licenses.
+// To test a different expression, change the expression, allowed licenses, and expected result in the function body.
+// TO RUN: go test ./spdxexp -run TestSatisfiesSingle
+func TestSatisfiesSingle(t *testing.T) {
+	// Update these to test a different expression.
+	expression := "BSD-3-Clause AND GPL-2.0"
+	allowedList := []string{"BSD-3-Clause", "GPL-2.0"}
+	expectedResult := true
+
+	// Run the test.
+	actualResult, err := Satisfies(expression, allowedList)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, actualResult)
+}
+
 func TestSatisfies(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
`TestSatisfiesSingle` lets you quickly test a single call to Satisfies with a specific license expression and allowed list of licenses.  

To test a different expression, edit `spdxexp/satisfies_test.go` and update `TestSatisfiesSingle` test to change in the function body...
* expression
* allowed licenses
* expected result

TO RUN: 
```
go test ./spdxexp -run TestSatisfiesSingle
```
