### PR TITLE
rename spdx package expression

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 ## Contributing
 
-[fork]: https://github.com/github/spdx-expression/fork
-[pr]: https://github.com/github/spdx-expression/compare
-[style]: https://github.com/github/spdx-expression/blob/main/.golangci.yaml
+[fork]: https://github.com/github/go-spdx
+[pr]: https://github.com/github/go-spdx/compare
+[style]: https://github.com/github/go-spdx/blob/main/.golangci.yaml
 [code-of-conduct]: CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# spdx-expression
+# go-spdx
 
 Golang implementation of a checker for determining if a set of SPDX IDs satisfies an SPDX Expression.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,10 +2,10 @@
 
 ## How to file issues and get help
 
-This project uses GitHub [issues](https://github.com/github/spdx-expression/issues) to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. If not found, file your bug or feaure request as a new issue.
+This project uses GitHub [issues](https://github.com/github/go-spdx/issues) to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. If not found, file your bug or feaure request as a new issue.
 
-For help or questions about using this project, please see the project [Discussions](https://github.com/github/spdx-expression/discussions) where you can ask a question in [Q&A](https://github.com/github/spdx-expression/discussions/categories/q-a), propose an idea in [Ideas](https://github.com/github/spdx-expression/discussions/categories/ideas), or share your work in [Show and Tell](https://github.com/github/spdx-expression/discussions/categories/show-and-tell).
+For help or questions about using this project, please see the project [Discussions](https://github.com/github/go-spdx/discussions) where you can ask a question in [Q&A](https://github.com/github/go-spdx/discussions/categories/q-a), propose an idea in [Ideas](https://github.com/github/go-spdx/discussions/categories/ideas), or share your work in [Show and Tell](https://github.com/github/go-spdx/discussions/categories/show-and-tell).
 
-The spdx-expression package is under active development and maintained by GitHub staff.  Community [contributions](./CONTRIBUTING.md) are always welcome. We will do our best to respond to issues, feature requests, and community questions in a timely manner.
+The go-spdx package is under active development and maintained by GitHub staff.  Community [contributions](./CONTRIBUTING.md) are always welcome. We will do our best to respond to issues, feature requests, and community questions in a timely manner.
 
 Support for this project is limited to the resources listed above.

--- a/expression/compare.go
+++ b/expression/compare.go
@@ -1,4 +1,4 @@
-package spdxexp
+package expression
 
 func compareGT(first *node, second *node) bool {
 	if !first.isLicense() || !second.isLicense() {

--- a/expression/compare_test.go
+++ b/expression/compare_test.go
@@ -1,4 +1,4 @@
-package spdxexp
+package expression
 
 import (
 	"testing"

--- a/expression/doc.go
+++ b/expression/doc.go
@@ -1,0 +1,7 @@
+/*
+Expression package validates licenses and determines if a license expression is satisfied by a list of licenses.
+Validity of a license is determined by the [SPDX license list].
+
+[SPDX license list]: https://spdx.org/licenses/
+*/
+package expression

--- a/expression/license.go
+++ b/expression/license.go
@@ -1,4 +1,4 @@
-package spdxexp
+package expression
 
 import (
 	"strings"

--- a/expression/license_test.go
+++ b/expression/license_test.go
@@ -1,4 +1,4 @@
-package spdxexp
+package expression
 
 import (
 	"testing"

--- a/expression/node.go
+++ b/expression/node.go
@@ -1,4 +1,4 @@
-package spdxexp
+package expression
 
 import (
 	"sort"

--- a/expression/node_test.go
+++ b/expression/node_test.go
@@ -1,4 +1,4 @@
-package spdxexp
+package expression
 
 import (
 	"testing"

--- a/expression/parse.go
+++ b/expression/parse.go
@@ -1,4 +1,4 @@
-package spdxexp
+package expression
 
 import (
 	"errors"

--- a/expression/parse_test.go
+++ b/expression/parse_test.go
@@ -1,4 +1,4 @@
-package spdxexp
+package expression
 
 import (
 	"errors"

--- a/expression/satisfies.go
+++ b/expression/satisfies.go
@@ -1,4 +1,4 @@
-package spdxexp
+package expression
 
 import (
 	"errors"

--- a/expression/satisfies_test.go
+++ b/expression/satisfies_test.go
@@ -1,4 +1,4 @@
-package spdxexp
+package expression
 
 import (
 	"errors"
@@ -31,7 +31,7 @@ func TestValidateLicenses(t *testing.T) {
 
 // TestSatisfiesSingle lets you quickly test a single call to Satisfies with a specific license expression and allowed list of licenses.
 // To test a different expression, change the expression, allowed licenses, and expected result in the function body.
-// TO RUN: go test ./spdxexp -run TestSatisfiesSingle
+// TO RUN: go test ./expression -run TestSatisfiesSingle
 func TestSatisfiesSingle(t *testing.T) {
 	// Update these to test a different expression.
 	expression := "BSD-3-Clause AND GPL-2.0"

--- a/expression/scan.go
+++ b/expression/scan.go
@@ -1,4 +1,4 @@
-package spdxexp
+package expression
 
 /* Translation to Go from javascript code: https://github.com/clearlydefined/spdx-expression-parse.js/blob/master/scan.js */
 

--- a/expression/scan_test.go
+++ b/expression/scan_test.go
@@ -1,4 +1,4 @@
-package spdxexp
+package expression
 
 import (
 	"errors"

--- a/expression/test_helper.go
+++ b/expression/test_helper.go
@@ -1,4 +1,4 @@
-package spdxexp
+package expression
 
 // getLicenseNode is a test helper method that is expected to create a valid
 // license node.  Use this function when the test data is known to be a valid

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/github/spdx-expression
+module github.com/github/go-spdx
 
 go 1.18
 

--- a/spdxexp/doc.go
+++ b/spdxexp/doc.go
@@ -1,7 +1,0 @@
-/*
-Spdxexp package validates licenses and determines if a license expression is satisfied by a list of licenses.
-Validity of a license is determined by the [SPDX license list].
-
-[SPDX license list]: https://spdx.org/licenses/
-*/
-package spdxexp


### PR DESCRIPTION
With the rename of `spdx-expressions` repo to `go-spdx`, the name of the package reads better as `expression`.  This allows for future changes to the API to be something like…

- go-spdx/expression - validation of expressions
- go-spdx/license - validation of licenses
- go-spdx/parse - parsing

This naming scheme more closely aligns with go conventions.