### PR TITLE
rename package from expression to spdxexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Golang implementation of a checker for determining if a set of SPDX IDs satisfies an SPDX Expression.
 
+## Installation
+
+There are several ways to include a go package.  To download and install, you can use `go get`.  The command for that is:
+
+```sh
+go get github.com/github/go-spdx@latest
+```
+
+## Packages
+
+- [spdxexp](https://pkg.go.dev/github.com/github/go-spdx/spdxexp) - Expression package validates licenses and determines if a license expression is satisfied by a list of licenses. Validity of a license is determined by the SPDX license list.
+
 ## Public API
 
 _NOTE: The public API is initially limited to the Satisfies and ValidateLicenses functions.  If

--- a/expression/doc.go
+++ b/expression/doc.go
@@ -1,7 +1,0 @@
-/*
-Expression package validates licenses and determines if a license expression is satisfied by a list of licenses.
-Validity of a license is determined by the [SPDX license list].
-
-[SPDX license list]: https://spdx.org/licenses/
-*/
-package expression

--- a/spdxexp/compare.go
+++ b/spdxexp/compare.go
@@ -1,4 +1,4 @@
-package expression
+package spdxexp
 
 func compareGT(first *node, second *node) bool {
 	if !first.isLicense() || !second.isLicense() {

--- a/spdxexp/compare_test.go
+++ b/spdxexp/compare_test.go
@@ -1,4 +1,4 @@
-package expression
+package spdxexp
 
 import (
 	"testing"

--- a/spdxexp/doc.go
+++ b/spdxexp/doc.go
@@ -1,0 +1,7 @@
+/*
+Spdxexp package validates licenses and determines if a license expression is satisfied by a list of licenses.
+Validity of a license is determined by the [SPDX license list].
+
+[SPDX license list]: https://spdx.org/licenses/
+*/
+package spdxexp

--- a/spdxexp/license.go
+++ b/spdxexp/license.go
@@ -1,4 +1,4 @@
-package expression
+package spdxexp
 
 import (
 	"strings"

--- a/spdxexp/license_test.go
+++ b/spdxexp/license_test.go
@@ -1,4 +1,4 @@
-package expression
+package spdxexp
 
 import (
 	"testing"

--- a/spdxexp/node.go
+++ b/spdxexp/node.go
@@ -1,4 +1,4 @@
-package expression
+package spdxexp
 
 import (
 	"sort"
@@ -167,7 +167,7 @@ func (n *node) reconstructedLicenseString() *string {
 	return nil
 }
 
-// Sort an array of license and license reference nodes alphebetically based
+// Sort an array of license and license reference nodes alphabetically based
 // on their reconstructedLicenseString() representation.  The sort function does not expect
 // expression nodes, but if one is in the nodes list, it will sort to the end.
 func sortLicenses(nodes []*node) {

--- a/spdxexp/node_test.go
+++ b/spdxexp/node_test.go
@@ -1,4 +1,4 @@
-package expression
+package spdxexp
 
 import (
 	"testing"

--- a/spdxexp/parse.go
+++ b/spdxexp/parse.go
@@ -1,4 +1,4 @@
-package expression
+package spdxexp
 
 import (
 	"errors"

--- a/spdxexp/parse_test.go
+++ b/spdxexp/parse_test.go
@@ -1,4 +1,4 @@
-package expression
+package spdxexp
 
 import (
 	"errors"

--- a/spdxexp/satisfies.go
+++ b/spdxexp/satisfies.go
@@ -1,4 +1,4 @@
-package expression
+package spdxexp
 
 import (
 	"errors"

--- a/spdxexp/satisfies_test.go
+++ b/spdxexp/satisfies_test.go
@@ -1,4 +1,4 @@
-package expression
+package spdxexp
 
 import (
 	"errors"

--- a/spdxexp/scan.go
+++ b/spdxexp/scan.go
@@ -1,4 +1,4 @@
-package expression
+package spdxexp
 
 /* Translation to Go from javascript code: https://github.com/clearlydefined/spdx-expression-parse.js/blob/master/scan.js */
 

--- a/spdxexp/scan_test.go
+++ b/spdxexp/scan_test.go
@@ -1,4 +1,4 @@
-package expression
+package spdxexp
 
 import (
 	"errors"

--- a/spdxexp/test_helper.go
+++ b/spdxexp/test_helper.go
@@ -1,4 +1,4 @@
-package expression
+package spdxexp
 
 // getLicenseNode is a test helper method that is expected to create a valid
 // license node.  Use this function when the test data is known to be a valid


### PR DESCRIPTION
Thoughts on the renaming:
- expression is long for a go package name
- exp is not specific (e.g. exp.Satisfies)
- spdxexp hits the balance between short length and enough info to quickly distinguish it from other packages (e.g. spdxexp.Satisfies)