### PR TITLE
module name must end in v2 for latest go conventions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/github/go-spdx
+module github.com/github/go-spdx/v2
 
 go 1.18
 


### PR DESCRIPTION
Reference: https://golang.cafe/blog/how-to-upgrade-to-a-major-version-in-go.html