### PR TITLE
fix bug where GPL-2.0 failed to match GPL-2.0-only

### DIFF
--- a/spdxexp/compare.go
+++ b/spdxexp/compare.go
@@ -1,5 +1,13 @@
 package spdxexp
 
+// The compare methods determine if two ranges are greater than, less than or equal within the same license group.
+// NOTE: Ranges are organized into groups (referred to as license groups) of the same base license (e.g. GPL).
+//       Groups have sub-groups of license versions (referred to as the range) where each member is considered
+//       to be the same version (e.g. {GPL-2.0, GPL-2.0-only}). The sub-groups are in ascending order within
+//       the license group, such that the first sub-group is considered to be less than the second sub-group,
+//       and so on. (e.g. {{GPL-1.0}, {GPL-2.0, GPL-2.0-only}} implies {GPL-1.0} < {GPL-2.0, GPL-2.0-only}).
+
+// compareGT returns true if the first range is greater than the second range within the same license group; otherwise, false.
 func compareGT(first *node, second *node) bool {
 	if !first.isLicense() || !second.isLicense() {
 		return false
@@ -13,6 +21,7 @@ func compareGT(first *node, second *node) bool {
 	return firstRange.location[versionGroup] > secondRange.location[versionGroup]
 }
 
+// compareLT returns true if the first range is less than the second range within the same license group; otherwise, false.
 func compareLT(first *node, second *node) bool {
 	if !first.isLicense() || !second.isLicense() {
 		return false
@@ -26,10 +35,15 @@ func compareLT(first *node, second *node) bool {
 	return firstRange.location[versionGroup] < secondRange.location[versionGroup]
 }
 
+// compareEQ returns true if the first and second range are the same range within the same license group; otherwise, false.
 func compareEQ(first *node, second *node) bool {
 	if !first.isLicense() || !second.isLicense() {
 		return false
 	}
+	if first.lic.license == second.lic.license {
+		return true
+	}
+
 	firstRange := getLicenseRange(*first.license())
 	secondRange := getLicenseRange(*second.license())
 
@@ -39,6 +53,8 @@ func compareEQ(first *node, second *node) bool {
 	return firstRange.location[versionGroup] == secondRange.location[versionGroup]
 }
 
+// sameLicenseGroup returns false if either license isn't in a range or the two ranges are
+// not in the same license group (e.g. group GPL != group Apache); otherwise, true
 func sameLicenseGroup(firstRange *licenseRange, secondRange *licenseRange) bool {
 	if firstRange == nil || secondRange == nil || firstRange.location[licenseGroup] != secondRange.location[licenseGroup] {
 		return false

--- a/spdxexp/compare_test.go
+++ b/spdxexp/compare_test.go
@@ -20,9 +20,12 @@ func TestCompareGT(t *testing.T) {
 		{"expect greater than: AGPL-3.0 > AGPL-1.0", getLicenseNode("AGPL-3.0", false), getLicenseNode("AGPL-1.0", false), true},
 		{"expect equal: GPL-2.0-or-later > GPL-2.0-only", getLicenseNode("GPL-2.0-or-later", true), getLicenseNode("GPL-2.0-only", false), false},
 		{"expect equal: GPL-2.0-or-later > GPL-2.0", getLicenseNode("GPL-2.0-or-later", true), getLicenseNode("GPL-2.0", false), false},
+		{"expect equal: GPL-2.0-only > GPL-2.0", getLicenseNode("GPL-2.0-only", false), getLicenseNode("GPL-2.0", false), false},
 		{"expect equal: GPL-3.0 > GPL-3.0", getLicenseNode("GPL-3.0", false), getLicenseNode("GPL-3.0", false), false},
+		{"expect equal: MIT > MIT", getLicenseNode("MIT", false), getLicenseNode("MIT", false), false},
 		{"expect less than: MPL-1.0 > MPL-2.0", getLicenseNode("MPL-1.0", false), getLicenseNode("MPL-2.0", false), false},
 		{"incompatible: MIT > ISC", getLicenseNode("MIT", false), getLicenseNode("ISC", false), false},
+		{"incompatible: MIT > GPL-2.0-only", getLicenseNode("MIT", false), getLicenseNode("GPL-2.0-only", false), false},
 		{"incompatible: OSL-1.0 > OPL-1.0", getLicenseNode("OSL-1.0", false), getLicenseNode("OPL-1.0", false), false},
 		{"not simple license: (MIT OR ISC) > GPL-3.0", getLicenseNode("(MIT OR ISC)", false), getLicenseNode("GPL-3.0", false), false}, // TODO: should it raise error?
 	}
@@ -49,9 +52,12 @@ func TestCompareEQ(t *testing.T) {
 		{"expect greater than: AGPL-3.0 == AGPL-1.0", getLicenseNode("AGPL-3.0", false), getLicenseNode("AGPL-1.0", false), false},
 		{"expect equal: GPL-2.0-or-later > GPL-2.0-only", getLicenseNode("GPL-2.0-or-later", true), getLicenseNode("GPL-2.0-only", false), true},
 		{"expect equal: GPL-2.0-or-later > GPL-2.0", getLicenseNode("GPL-2.0-or-later", true), getLicenseNode("GPL-2.0", false), true},
+		{"expect equal: GPL-2.0-only == GPL-2.0", getLicenseNode("GPL-2.0-only", false), getLicenseNode("GPL-2.0", false), true},
 		{"expect equal: GPL-3.0 == GPL-3.0", getLicenseNode("GPL-3.0", false), getLicenseNode("GPL-3.0", false), true},
+		{"expect equal: MIT == MIT", getLicenseNode("MIT", false), getLicenseNode("MIT", false), true},
 		{"expect less than: MPL-1.0 == MPL-2.0", getLicenseNode("MPL-1.0", false), getLicenseNode("MPL-2.0", false), false},
 		{"incompatible: MIT == ISC", getLicenseNode("MIT", false), getLicenseNode("ISC", false), false},
+		{"incompatible: MIT == GPL-2.0-only", getLicenseNode("MIT", false), getLicenseNode("GPL-2.0-only", false), false},
 		{"incompatible: OSL-1.0 == OPL-1.0", getLicenseNode("OSL-1.0", false), getLicenseNode("OPL-1.0", false), false},
 		{"not simple license: (MIT OR ISC) == GPL-3.0", getLicenseNode("(MIT OR ISC)", false), getLicenseNode("GPL-3.0", false), false}, // TODO: should it raise error?
 	}
@@ -78,9 +84,12 @@ func TestCompareLT(t *testing.T) {
 		{"expect greater than: AGPL-3.0 < AGPL-1.0", getLicenseNode("AGPL-3.0", false), getLicenseNode("AGPL-1.0", false), false},
 		{"expect greater than: GPL-2.0-or-later < GPL-2.0-only", getLicenseNode("GPL-2.0-or-later", true), getLicenseNode("GPL-2.0-only", false), false},
 		{"expect greater than: GPL-2.0-or-later == GPL-2.0", getLicenseNode("GPL-2.0-or-later", true), getLicenseNode("GPL-2.0", false), false},
+		{"expect equal: GPL-2.0-only < GPL-2.0", getLicenseNode("GPL-2.0-only", false), getLicenseNode("GPL-2.0", false), false},
 		{"expect equal: GPL-3.0 < GPL-3.0", getLicenseNode("GPL-3.0", false), getLicenseNode("GPL-3.0", false), false},
+		{"expect equal: MIT < MIT", getLicenseNode("MIT", false), getLicenseNode("MIT", false), false},
 		{"expect less than: MPL-1.0 < MPL-2.0", getLicenseNode("MPL-1.0", false), getLicenseNode("MPL-2.0", false), true},
 		{"incompatible: MIT < ISC", getLicenseNode("MIT", false), getLicenseNode("ISC", false), false},
+		{"incompatible: MIT < GPL-2.0-only", getLicenseNode("MIT", false), getLicenseNode("GPL-2.0-only", false), false},
 		{"incompatible: OSL-1.0 < OPL-1.0", getLicenseNode("OSL-1.0", false), getLicenseNode("OPL-1.0", false), false},
 		{"not simple license: (MIT OR ISC) < GPL-3.0", getLicenseNode("(MIT OR ISC)", false), getLicenseNode("GPL-3.0", false), false}, // TODO: should it raise error?
 	}

--- a/spdxexp/license.go
+++ b/spdxexp/license.go
@@ -640,6 +640,13 @@ func getExceptions() []string {
 	}
 }
 
+// licenseRanges returns a list of license ranges.
+//
+// Ranges are organized into groups (referred to as license groups) of the same base license (e.g. GPL).
+// Groups have sub-groups of license versions (referred to as the range) where each member is considered
+// to be the same version (e.g. {GPL-2.0, GPL-2.0-only}). The sub-groups are in ascending order within
+// the license group, such that the first sub-group is considered to be less than the second sub-group,
+// and so on. (e.g. {{GPL-1.0}, {GPL-2.0, GPL-2.0-only}} implies {GPL-1.0} < {GPL-2.0, GPL-2.0-only}).
 func licenseRanges() [][][]string {
 	return [][][]string{
 		{

--- a/spdxexp/satisfies_test.go
+++ b/spdxexp/satisfies_test.go
@@ -18,6 +18,8 @@ func TestValidateLicenses(t *testing.T) {
 		{"All invalid", []string{"MTI", "Apche-2.0", "0xDEADBEEF", ""}, false, []string{"MTI", "Apche-2.0", "0xDEADBEEF", ""}},
 		{"All valid", []string{"MIT", "Apache-2.0", "GPL-2.0"}, true, []string{}},
 		{"Some invalid", []string{"MTI", "Apche-2.0", "GPL-2.0"}, false, []string{"MTI", "Apche-2.0"}},
+		{"GPL-2.0", []string{"GPL-2.0"}, true, []string{}},
+		{"GPL-2.0-only", []string{"GPL-2.0-only"}, true, []string{}},
 	}
 
 	for _, test := range tests {
@@ -110,6 +112,8 @@ func TestSatisfies(t *testing.T) {
 		{"GPL-1.0+ satisfies [GPL-2.0+]", "GPL-1.0+", []string{"GPL-2.0+"}, true, nil},
 		{"! GPL-1.0 satisfies [GPL-2.0+]", "GPL-1.0", []string{"GPL-2.0+"}, false, nil},
 		{"GPL-2.0-only satisfies [GPL-2.0-only]", "GPL-2.0-only", []string{"GPL-2.0-only"}, true, nil},
+		{"GPL-2.0 satisfies [GPL-2.0-only]", "GPL-2.0", []string{"GPL-2.0-only"}, true, nil},
+		{"GPL-2.0 AND GPL-2.0-only satisfies [GPL-2.0-only]", "GPL-2.0 AND GPL-2.0-only", []string{"GPL-2.0-only"}, true, nil},
 		{"GPL-3.0-only satisfies [GPL-2.0+]", "GPL-3.0-only", []string{"GPL-2.0+"}, true, nil},
 
 		{"! GPL-2.0 satisfies [GPL-2.0+ WITH Bison-exception-2.2]",


### PR DESCRIPTION
### Description

Testing the policy service identified a bug where `GPL-2.0` was not allowed for `GPL-2.0-only`.  This PR does some cleanup on `node.go` to lay out the comparisons more clearly and fix the bug.

### Changes

Most of the changes are adding test-cases that would have caught the bug.  The only substantive changes are in the range checks in `node.go`.  There is one minor change to `compareEQ()` to short cut the comparison if the two licenses are the same.

* check all simple cases before checking ranges (i.e. nodes are not licenses, exceptions are not equal, licenses are exactly equal) _This is less expensive than range checks._
* remove any simple checks that were repeated in range check methods
* add comment describing license ranges
* add comments about what is expected depending on whether one or both licenses have `has_plus==true`
* fix the bug by checking that both license are in the same range when neither node `has_plus` 
