### PR TITLE
docs: add expressions to `Validate` test cases and API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ assert.Contains(invalidLicenses, "NON-EXISTENT-LICENSE")
 assert.NotContains(invalidLicenses, "MIT")
 ```
 
+#### Examples: ValidateLicenses works with SPDX expressions
+
+```go
+valid, invalidLicenses := ValidateLicenses([]string{"MIT AND APACHE-2.0"})
+assert.True(valid)
+assert.NotContains(invalidLicenses, "MIT AND APACHE-2.0")
+```
+
+
 ## Background
 
 This package was developed to support testing whether a repository's license requirements are met by an allowed-list of licenses.

--- a/spdxexp/parse_test.go
+++ b/spdxexp/parse_test.go
@@ -919,7 +919,7 @@ func TestParse(t *testing.T) {
 			require.Equal(t, test.err, err)
 			if test.err != nil {
 				// when error, check that returned node is nil
-				var nilNode *node = nil
+				var nilNode *node
 				assert.Equal(t, nilNode, startNode, "Expected nil node when error occurs.")
 				return
 			}
@@ -1115,7 +1115,7 @@ func TestParseTokens(t *testing.T) {
 			require.Equal(t, test.err, test.tokens.err)
 			if test.err != nil {
 				// when error, check that returned node is nil
-				var nilNode *node = nil
+				var nilNode *node
 				assert.Equal(t, nilNode, startNode, "Expected nil node when error occurs.")
 				return
 			}
@@ -1257,7 +1257,7 @@ func TestParseWith(t *testing.T) {
 			require.Equal(t, test.err, test.tokens.err)
 			if test.expectNil {
 				// exception license is nil when error occurs or WITH operator is not found
-				var nilString *string = nil
+				var nilString *string
 				assert.Equal(t, nilString, exceptionLicense)
 				return
 			}

--- a/spdxexp/satisfies_test.go
+++ b/spdxexp/satisfies_test.go
@@ -20,6 +20,12 @@ func TestValidateLicenses(t *testing.T) {
 		{"Some invalid", []string{"MTI", "Apche-2.0", "GPL-2.0"}, false, []string{"MTI", "Apche-2.0"}},
 		{"GPL-2.0", []string{"GPL-2.0"}, true, []string{}},
 		{"GPL-2.0-only", []string{"GPL-2.0-only"}, true, []string{}},
+		{"SPDX Expressions are valid", []string{
+			"MIT AND APACHE-2.0",
+			"MIT AND APCHE-2.0",
+			"LGPL-2.1-only OR MIT OR BSD-3-Clause",
+			"GPL-2.0-or-later WITH Bison-exception-2.2",
+		}, false, []string{"MIT AND APCHE-2.0"}},
 	}
 
 	for _, test := range tests {

--- a/spdxexp/scan.go
+++ b/spdxexp/scan.go
@@ -269,10 +269,8 @@ func (exp *expressionStream) normalizeLicense(license string) *token {
 			return token
 		}
 	}
-	if token := deprecatedLicenseLookup(license); token != nil {
-		return token
-	}
-	return nil
+
+	return deprecatedLicenseLookup(license)
 }
 
 // Lookup license identifier in active and exception lists to determine if it is a supported SPDX id

--- a/spdxexp/scan_test.go
+++ b/spdxexp/scan_test.go
@@ -127,7 +127,7 @@ func TestParseToken(t *testing.T) {
 			require.Equal(t, test.err, test.exp.err)
 			if test.err != nil {
 				// token is nil when error occurs or token is not recognized
-				var nilToken *token = nil
+				var nilToken *token
 				assert.Equal(t, nilToken, tokn)
 				return
 			}
@@ -298,7 +298,7 @@ func TestReadDocumentRef(t *testing.T) {
 			require.Equal(t, test.err, test.exp.err)
 			if test.err != nil {
 				// ref should be nil when error occurs or a ref is not found
-				var nilToken *token = nil
+				var nilToken *token
 				assert.Equal(t, nilToken, ref, "Expected nil token when error occurs.")
 				return
 			}
@@ -331,7 +331,7 @@ func TestReadLicenseRef(t *testing.T) {
 			require.Equal(t, test.err, test.exp.err)
 			if test.err != nil {
 				// ref should be nil when error occurs or a ref is not found
-				var nilToken *token = nil
+				var nilToken *token
 				assert.Equal(t, nilToken, ref)
 				return
 			}
@@ -371,7 +371,7 @@ func TestReadLicense(t *testing.T) {
 			require.Equal(t, test.err, test.exp.err)
 			if test.err != nil {
 				// license should be nil when error occurs or a license is not found
-				var nilToken *token = nil
+				var nilToken *token
 				assert.Equal(t, nilToken, license)
 				return
 			}


### PR DESCRIPTION
Closes #36 

👋  - Thanks for taking the time to look at this PR - I started this thinking [syft](https://github.com/anchore/syft) would need to leverage the `parse` function as part of this libraries public API to get `node` which would give `ReconstructLicenseString`. We're revamping some of how we do license detection/presentation and I wanted a way to be sure that if we return an expression it's valid.

I was very pleased after experimenting more that `ValidateLicenses` could be used with complex spdx expressions.

I opened issue #36 a little while ago, but think we can close it given this PR updates the docs/tests to point users to this additional use case of complex expressions as inputs to validate.


### Linting changes
When I downloaded the latest `golangci-lint` I saw a few changes that I boy scouted, but can drop that commit if you all have a different configuration for the linter (I double checked it was using the config found in the repo, but have been tripped up by this before). I noticed there was some excludes for `revive`, but don't think my changes synced with those exclusions:

![Screenshot 2023-04-13 at 12 30 41 PM](https://github.com/github/go-spdx/assets/32073428/c3c064af-5811-4075-951a-d4b4ca197842)

Thanks for the great library!