### PR TITLE
ignore new name for official spdx repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@
 # vendor/
 
 # Ignore path setup by fetch-licenses workflow
-spdx-license-list-data/
+official-spdx-licenses/


### PR DESCRIPTION
Changed name used for temp directory holding the official SPDX licenses when running the fetch-licenses workflow.  This improves readability.