### PR TITLE
retract v2.3.0 in v2.3.1 returning to go 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Go Reference](https://pkg.go.dev/badge/github.com/github/go-spdx/v2@v2.3.0/spdxexp.svg)](https://pkg.go.dev/github.com/github/go-spdx/v2@v2.3.0/spdxexp)
-[![Go Reference](https://pkg.go.dev/badge/github.com/github/go-spdx/v2@v2.3.0/spdxlicenses.svg)](https://pkg.go.dev/github.com/github/go-spdx/v2@v2.3.0/spdxlicenses)
+[![Go Reference](https://pkg.go.dev/badge/github.com/github/go-spdx/v2@v2.3.1/spdxexp.svg)](https://pkg.go.dev/github.com/github/go-spdx/v2@v2.3.1/spdxexp)
+[![Go Reference](https://pkg.go.dev/badge/github.com/github/go-spdx/v2@v2.3.1/spdxlicenses.svg)](https://pkg.go.dev/github.com/github/go-spdx/v2@v2.3.1/spdxlicenses)
 
 # go-spdx
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/github/go-spdx/v2
 
-go 1.22
+retract v2.3.0 // Compatibility issues with go 1.22
+
+go 1.21
 
 require github.com/stretchr/testify v1.8.0
 


### PR DESCRIPTION
There seem to be compatibility issues with go 1.22.  This retracts release v2.3.0 which used go 1.22 and adds release v2.3.1 which goes back to using go 1.21.