### PR TITLE
add ability to force tests to run

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request: {}
+  workflow_dispatch: # Sometimes tests get stuck in PRs; This allows them to be rerun manually
 
 permissions:
   contents: read


### PR DESCRIPTION
### Description

This PR also adds the ability to force tests to run in the `test.yaml` workflow. This workflow gets stuck sometimes when triggered by PRs. Adding workflow_dispatch avoids the need to do a minor change (e.g. adding whitespace to a file) just to get the tests to run again.