### PR TITLE
Update Go Reference badges to version 2.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Go Reference](https://pkg.go.dev/badge/github.com/github/go-spdx/v2@v2.3.3/spdxexp.svg)](https://pkg.go.dev/github.com/github/go-spdx/v2@v2.3.3/spdxexp)
-[![Go Reference](https://pkg.go.dev/badge/github.com/github/go-spdx/v2@v2.3.3/spdxlicenses.svg)](https://pkg.go.dev/github.com/github/go-spdx/v2@v2.3.3/spdxlicenses)
+<sub>[![Go Reference](https://pkg.go.dev/badge/github.com/github/go-spdx/v2@v2.3.4/spdxexp.svg)](https://pkg.go.dev/github.com/github/go-spdx/v2@v2.3.4/spdxexp) spdxexp</sub> <br>
+<sub>[![Go Reference](https://pkg.go.dev/badge/github.com/github/go-spdx/v2@v2.3.4/spdxlicenses.svg)](https://pkg.go.dev/github.com/github/go-spdx/v2@v2.3.4/spdxlicenses) spdxlicenses</sub>
 
 # go-spdx
 


### PR DESCRIPTION
update readme refs to point to v2.3.4 release in pkg.go.dev