### PR TITLE
Delete CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# This repository is maintained by: 
-* @elrayle @dangoor @github/dependency-graph-reviewers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # This repository is maintained by: 
-* @elrayle @ajhenry @dangoor
+* @elrayle @dangoor @github/dependency-graph-reviewers


### PR DESCRIPTION
Since this repo doesn't have split ownership, it's easy to manage who can maintain this via the repository settings.